### PR TITLE
fix: Correct Dataflow Flex Template build errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,11 +317,36 @@ cat > analysis-dataflow-pipeline/metadata.json << EOF
     "name": "Market News Analysis",
     "description": "A Dataflow pipeline that analyzes financial news with Vertex AI.",
     "parameters": [
-        { "name": "input_subscription", "label": "Input Pub/Sub subscription", "param_type": "TEXT" },
-        { "name": "output_table", "label": "Output BigQuery table", "param_type": "TEXT" },
-        { "name": "sentiment_images_bucket_name", "label": "Sentiment images bucket", "param_type": "TEXT" },
-        { "name": "project_id", "label": "Project ID", "param_type": "TEXT" },
-        { "name": "region", "label": "Region", "param_type": "TEXT" }
+        {
+            "name": "input_subscription",
+            "label": "Input Pub/Sub subscription",
+            "helpText": "The Pub/Sub subscription to read messages from. Format: projects/<PROJECT_ID>/subscriptions/<SUBSCRIPTION_ID>",
+            "param_type": "TEXT"
+        },
+        {
+            "name": "output_table",
+            "label": "Output BigQuery table",
+            "helpText": "The BigQuery table to write results to. Format: <PROJECT_ID>:<DATASET_ID>.<TABLE_ID>",
+            "param_type": "TEXT"
+        },
+        {
+            "name": "sentiment_images_bucket_name",
+            "label": "Sentiment images bucket name",
+            "helpText": "The GCS bucket to store generated sentiment chart icons in.",
+            "param_type": "TEXT"
+        },
+        {
+            "name": "project_id",
+            "label": "Project ID",
+            "helpText": "The GCP project ID.",
+            "param_type": "TEXT"
+        },
+        {
+            "name": "region",
+            "label": "Region",
+            "helpText": "The GCP region to run the Dataflow job in.",
+            "param_type": "TEXT"
+        }
     ]
 }
 EOF

--- a/analysis-dataflow-pipeline/metadata.json
+++ b/analysis-dataflow-pipeline/metadata.json
@@ -5,31 +5,31 @@
         {
             "name": "input_subscription",
             "label": "Input Pub/Sub subscription",
-            "help_text": "The Pub/Sub subscription to read messages from.",
+            "helpText": "The Pub/Sub subscription to read messages from. Format: projects/<PROJECT_ID>/subscriptions/<SUBSCRIPTION_ID>",
             "param_type": "TEXT"
         },
         {
             "name": "output_table",
             "label": "Output BigQuery table",
-            "help_text": "The BigQuery table to write results to.",
+            "helpText": "The BigQuery table to write results to. Format: <PROJECT_ID>:<DATASET_ID>.<TABLE_ID>",
             "param_type": "TEXT"
         },
         {
             "name": "sentiment_images_bucket_name",
             "label": "Sentiment images bucket name",
-            "help_text": "The GCS bucket to store generated sentiment chart icons in.",
+            "helpText": "The GCS bucket to store generated sentiment chart icons in.",
             "param_type": "TEXT"
         },
         {
             "name": "project_id",
             "label": "Project ID",
-            "help_text": "The GCP project ID.",
+            "helpText": "The GCP project ID.",
             "param_type": "TEXT"
         },
         {
             "name": "region",
             "label": "Region",
-            "help_text": "The GCP region to run the Dataflow job in.",
+            "helpText": "The GCP region to run the Dataflow job in.",
             "param_type": "TEXT"
         }
     ]


### PR DESCRIPTION
This commit resolves two errors encountered when building and deploying the Dataflow Flex Template for the fintech workshop:

1. A `ValueError` was raised during the `gcloud dataflow flex-template build` command because the `metadata.json` file was missing the required `helpText` field for its parameters. This has been corrected by adding `helpText` to each parameter in the `metadata.json` file and the corresponding `README.md` instructions.

2. A previous error (`Dockerfile required`) was fixed by adding a `Dockerfile`, but the user encountered the metadata error afterward. This commit includes the metadata fix on top of the Dockerfile fix.

These changes ensure that the workshop instructions are correct and the Dataflow pipeline can be successfully built and deployed.