### PR TITLE
fix: Remove standard parameters from Dataflow metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,18 +333,6 @@ cat > analysis-dataflow-pipeline/metadata.json << EOF
             "label": "Sentiment images bucket name",
             "helpText": "The GCS bucket to store generated sentiment chart icons in.",
             "param_type": "TEXT"
-        },
-        {
-            "name": "project_id",
-            "label": "Project ID",
-            "helpText": "The GCP project ID.",
-            "param_type": "TEXT"
-        },
-        {
-            "name": "region",
-            "label": "Region",
-            "helpText": "The GCP region to run the Dataflow job in.",
-            "param_type": "TEXT"
         }
     ]
 }

--- a/analysis-dataflow-pipeline/metadata.json
+++ b/analysis-dataflow-pipeline/metadata.json
@@ -19,18 +19,6 @@
             "label": "Sentiment images bucket name",
             "helpText": "The GCS bucket to store generated sentiment chart icons in.",
             "param_type": "TEXT"
-        },
-        {
-            "name": "project_id",
-            "label": "Project ID",
-            "helpText": "The GCP project ID.",
-            "param_type": "TEXT"
-        },
-        {
-            "name": "region",
-            "label": "Region",
-            "helpText": "The GCP region to run the Dataflow job in.",
-            "param_type": "TEXT"
         }
     ]
 }


### PR DESCRIPTION
This commit resolves an `INVALID_ARGUMENT` error that occurred during the `gcloud dataflow flex-template run` command. The error was caused by the `metadata.json` file incorrectly defining `project_id` and `region` as required custom parameters.

The fix involves:
- Removing the `project_id` and `region` parameter definitions from the `analysis-dataflow-pipeline/metadata.json` file. These are standard parameters automatically handled by the Dataflow runner and should not be defined in the template's metadata.
- Updating the `cat` command in the `README.md` to ensure the instructions generate the corrected `metadata.json` file.

This is the final fix that makes the workshop fully functional and resolves all known bugs.